### PR TITLE
feat: Implement dark mode toggle switch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,39 +4,37 @@ void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool _isDarkMode = false;
+
+  void _toggleTheme() {
+    setState(() {
+      _isDarkMode = !_isDarkMode;
+    });
+  }
 
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      theme: ThemeData(brightness: Brightness.light),
+      darkTheme: ThemeData(brightness: Brightness.dark),
+      themeMode: _isDarkMode ? ThemeMode.dark : ThemeMode.light,
+      home: MyHomePage(title: 'Flutter Demo Home Page', isDarkMode: _isDarkMode, onThemeChanged: _toggleTheme),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({super.key, required this.title, required this.isDarkMode, required this.onThemeChanged});
 
   // This widget is the home page of your application. It is stateful, meaning
   // that it has a State object (defined below) that contains fields that affect
@@ -48,6 +46,8 @@ class MyHomePage extends StatefulWidget {
   // always marked "final".
 
   final String title;
+  final bool isDarkMode;
+  final VoidCallback onThemeChanged;
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
@@ -108,6 +108,21 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  const Text('Dark Mode'),
+                  Switch(
+                    value: widget.isDarkMode,
+                    onChanged: (value) {
+                      widget.onThemeChanged();
+                    },
+                  ),
+                ],
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
This commit introduces a theme toggle functionality to the Flutter application.

Key changes:
- Modified `MyApp` to be a `StatefulWidget` to manage theme state.
- Added `_isDarkMode` state variable and `_toggleTheme` function in `_MyAppState`.
- Updated `MaterialApp` to use `theme`, `darkTheme`, and `themeMode` properties based on the theme state.
- Passed theme state and toggle function down to `MyHomePage`.
- Added a `Switch` widget in `MyHomePage` to allow you to toggle between light and dark themes.