### PR TITLE
Fix: Resolve "Entrypoint isn't within the current project" error

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -41,5 +41,4 @@ migration:
   #
   # Files that are not part of the templates will be ignored by default.
   unmanaged_files:
-    - 'lib/main.dart'
     - 'ios/Runner.xcodeproj/project.pbxproj'


### PR DESCRIPTION
I removed `lib/main.dart` from the `unmanaged_files` list in the `.metadata` file. This change is intended to allow the Flutter tooling to correctly identify your project's entrypoint.

Due to limitations in my execution environment, I was unable to verify that this change resolves the issue by running your application. However, this is a common solution for this type of error.